### PR TITLE
Ignore logging event when the serializer is the Null serializer.

### DIFF
--- a/lib/active_model_serializers/logging.rb
+++ b/lib/active_model_serializers/logging.rb
@@ -104,8 +104,10 @@ module ActiveModelSerializers
 
     class LogSubscriber < ActiveSupport::LogSubscriber
       def render(event)
+        serializer = event.payload[:serializer]
+        return if serializer == ActiveModel::Serializer::Null
+
         info do
-          serializer = event.payload[:serializer]
           adapter = event.payload[:adapter]
           duration = event.duration.round(2)
           "Rendered #{serializer.name} with #{adapter.class} (#{duration}ms)"

--- a/test/active_model_serializers/logging_test.rb
+++ b/test/active_model_serializers/logging_test.rb
@@ -72,6 +72,11 @@ module ActiveModel
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/\(\d+\.\d+ms\)/, @logger.messages)
       end
+
+      def test_logs_without_serializer
+        ActiveModelSerializers::SerializableResource.new(foo: :bar).to_json
+        assert_equal('', @logger.messages)
+      end
     end
   end
 end


### PR DESCRIPTION
This removes log lines when AMS doesn't have a serializer for the
object. It keeps the same payload because I don't know if people using
AMS rely already on having not nil objects in that payload.

Signed-off-by: David Calavera <david.calavera@gmail.com>